### PR TITLE
Use default order for coordinates

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ Geokit is a PHP toolkit to solve geo-related tasks like:
 
 * [Installation](#installation)
 * [Reference](#reference)
-  * [LngLat](#lnglat)
+  * [LatLng](#latlng)
   * [Bounds](#bounds)
   * [Distance](#distance)
 * [License](#license)
@@ -36,41 +36,41 @@ available versions.
 Reference
 ---------
 
-### LngLat
+### LatLng
 
-A LngLat instance represents a geographical point in longitude/latitude
+A LatLng instance represents a geographical point in latitude/longitude
 coordinates.
 
-* Longitude ranges between -180 and 180 degrees, inclusive. Longitudes above 180
-  or below -180 are wrapped. For example, 480, 840 and 1200 will all be wrapped
-  to 120 degrees.
 * Latitude ranges between -90 and 90 degrees, inclusive. Latitudes above 90 or
   below -90 are capped, not wrapped. For example, 100 will be capped to 90
   degrees.
+* Longitude ranges between -180 and 180 degrees, inclusive. Longitudes above 180
+  or below -180 are wrapped. For example, 480, 840 and 1200 will all be wrapped
+  to 120 degrees.
 
 ```php
-$lngLat = new Geokit\LngLat(1, 2);
+$latLng = new Geokit\LatLng(1, 2);
 
-$longitude = $lngLat->getLongitude();
+$latitude = $latLng->getLatitude();
 // or
-$longitude = $lngLat['longitude'];
+$latitude = $latLng['latitude'];
 
-$latitude = $lngLat->getLatitude();
+$longitude = $latLng->getLongitude();
 // or
-$latitude = $lngLat['latitude'];
+$longitude = $latLng['longitude'];
 ```
 
-Alternatively, you can create a LngLat instance through its static normalize
+Alternatively, you can create a LatLng instance through its static normalize
 method. This method takes anything which looks like a coordinate and generates a
-LngLat object from it.
+LatLng object from it.
 
 ```php
-$lngLat = Geokit\LngLat::normalize('1 2');
-$lngLat = Geokit\LngLat::normalize('1, 2');
-$lngLat = Geokit\LngLat::normalize(array('longitude' => 1, 'latitude' => 2));
-$lngLat = Geokit\LngLat::normalize(array('lng' => 1, 'lat' => 2));
-$lngLat = Geokit\LngLat::normalize(array('lon' => 1, 'lat' => 2));
-$lngLat = Geokit\LngLat::normalize(array(1, 2));
+$latLng = Geokit\LatLng::normalize('1 2');
+$latLng = Geokit\LatLng::normalize('1, 2');
+$latLng = Geokit\LatLng::normalize(array('latitude' => 1, 'longitude' => 2));
+$latLng = Geokit\LatLng::normalize(array('lat' => 1, 'lng' => 2));
+$latLng = Geokit\LatLng::normalize(array('lat' => 1, 'lon' => 2));
+$latLng = Geokit\LatLng::normalize(array(1, 2));
 ```
 
 ### Bounds
@@ -78,30 +78,30 @@ $lngLat = Geokit\LngLat::normalize(array(1, 2));
 A Bounds instance represents a rectangle in geographical coordinates, including
 one that crosses the 180 degrees longitudinal meridian.
 
-It is constructed from its left/bottom (west-south) and right-top (east-north)
+It is constructed from its left/bottom (south-west) and right-top (north-east)
 corner points.
 
 ```php
-$westSouth = new Geokit\LngLat(1, 2);
-$eastNorth = new Geokit\LngLat(1, 2);
+$southWest = new Geokit\LatLng(1, 2);
+$northEast = new Geokit\LatLng(1, 2);
 
-$bounds = new Geokit\Bounds($westSouth, $eastNorth);
+$bounds = new Geokit\Bounds($southWest, $northEast);
 
-$westSouthLngLat = $bounds->getWestSouth();
+$southWestLatLng = $bounds->getSouthWest();
 // or
-$westSouthLngLat = $bounds['west_south'];
+$southWestLatLng = $bounds['south_west'];
 
-$eastNorthLngLat = $bounds->getEastNorth();
+$northEastLatLng = $bounds->getNorthEast();
 // or
-$eastNorthLngLat = $bounds['east_north'];
+$northEastLatLng = $bounds['north_east'];
 
-$centerLngLat = $bounds->getCenter();
+$centerLatLng = $bounds->getCenter();
 // or
-$centerLngLat = $bounds['center'];
+$centerLatLng = $bounds['center'];
 
-$spanLngLat = $bounds->getSpan();
+$spanLatLng = $bounds->getSpan();
 // or
-$spanLngLat = $bounds['span'];
+$spanLatLng = $bounds['span'];
 
 $boolean = $bounds->contains($latLng);
 
@@ -114,14 +114,14 @@ method. This method takes anything which looks like bounds and generates a
 Bounds object from it.
 
 ```php
-$lngLat = Geokit\Bounds::normalize('1 2 3 4');
-$lngLat = Geokit\Bounds::normalize('1 2, 3 4');
-$lngLat = Geokit\Bounds::normalize('1, 2, 3, 4');
-$lngLat = Geokit\Bounds::normalize(array('west_south' => $westSouthLngLat, 'east_north' => $eastNorthLngLat));
-$lngLat = Geokit\Bounds::normalize(array('west_south' => array(1, 2), 'east_north' => array(3, 4)));
-$lngLat = Geokit\Bounds::normalize(array('westsouth' => $westSouthLngLat, 'eastnorth' => $eastNorthLngLat));
-$lngLat = Geokit\Bounds::normalize(array('westSouth' => $westSouthLngLat, 'eastNorth' => $eastNorthLngLat));
-$lngLat = Geokit\Bounds::normalize(array($westSouthLngLat, $eastNorthLngLat));
+$latLng = Geokit\Bounds::normalize('1 2 3 4');
+$latLng = Geokit\Bounds::normalize('1 2, 3 4');
+$latLng = Geokit\Bounds::normalize('1, 2, 3, 4');
+$latLng = Geokit\Bounds::normalize(array('south_west' => $southWestLatLng, 'north_east' => $northEastLatLng));
+$latLng = Geokit\Bounds::normalize(array('south_west' => array(1, 2), 'north_east' => array(3, 4)));
+$latLng = Geokit\Bounds::normalize(array('southwest' => $southWestLatLng, 'northeast' => $northEastLatLng));
+$latLng = Geokit\Bounds::normalize(array('southWest' => $southWestLatLng, 'northEast' => $northEastLatLng));
+$latLng = Geokit\Bounds::normalize(array($southWestLatLng, $northEastLatLng));
 ```
 
 ### Distance

--- a/src/Bounds.php
+++ b/src/Bounds.php
@@ -13,96 +13,96 @@ namespace Geokit;
 
 class Bounds implements \ArrayAccess
 {
-    private $westSouth;
-    private $eastNorth;
+    private $southWest;
+    private $northEast;
 
-    private static $westSouthKeys = array(
-        'westsouth',
-        'west_south',
-        'westSouth'
+    private static $southWestKeys = array(
+        'southwest',
+        'south_west',
+        'southWest'
     );
 
-    private static $eastNorthKeys = array(
-        'eastnorth',
-        'east_north',
-        'eastNorth'
+    private static $northEastKeys = array(
+        'northeast',
+        'north_east',
+        'northEast'
     );
 
     /**
-     * @param  \Geokit\LngLat  $westSouth
-     * @param  \Geokit\LngLat  $eastNorth
+     * @param  \Geokit\LatLng  $southWest
+     * @param  \Geokit\LatLng  $northEast
      * @throws \LogicException
      */
-    public function __construct(LngLat $westSouth, LngLat $eastNorth)
+    public function __construct(LatLng $southWest, LatLng $northEast)
     {
-        $this->westSouth = $westSouth;
-        $this->eastNorth = $eastNorth;
+        $this->southWest = $southWest;
+        $this->northEast = $northEast;
 
-        if ($this->westSouth->getLatitude() > $this->eastNorth->getLatitude()) {
-            throw new \LogicException('Bounds west-south coordinate cannot be north of the east-north coordinate');
+        if ($this->southWest->getLatitude() > $this->northEast->getLatitude()) {
+            throw new \LogicException('Bounds south-west coordinate cannot be north of the east-north coordinate');
         }
     }
 
     /**
-     * @return \Geokit\LngLat
+     * @return \Geokit\LatLng
      */
-    public function getWestSouth()
+    public function getSouthWest()
     {
-        return $this->westSouth;
+        return $this->southWest;
     }
 
     /**
-     * @return \Geokit\LngLat
+     * @return \Geokit\LatLng
      */
-    public function getEastNorth()
+    public function getNorthEast()
     {
-        return $this->eastNorth;
+        return $this->northEast;
     }
 
     /**
-     * @return \Geokit\LngLat
+     * @return \Geokit\LatLng
      */
     public function getCenter()
     {
         if ($this->crossesAntimeridian()) {
-            $span = $this->lngSpan($this->westSouth->getLongitude(), $this->eastNorth->getLongitude());
-            $lng  = $this->westSouth->getLongitude() + $span / 2;
+            $span = $this->lngSpan($this->southWest->getLongitude(), $this->northEast->getLongitude());
+            $lng  = $this->southWest->getLongitude() + $span / 2;
         } else {
-            $lng = ($this->westSouth->getLongitude() + $this->eastNorth->getLongitude()) / 2;
+            $lng = ($this->southWest->getLongitude() + $this->northEast->getLongitude()) / 2;
         }
 
-        return new LngLat(
-            $lng,
-            ($this->westSouth->getLatitude() + $this->eastNorth->getLatitude()) / 2
+        return new LatLng(
+            ($this->southWest->getLatitude() + $this->northEast->getLatitude()) / 2,
+            $lng
         );
     }
 
     /**
-     * @return \Geokit\LngLat
+     * @return \Geokit\LatLng
      */
     public function getSpan()
     {
-        return new LngLat(
-            $this->lngSpan($this->westSouth->getLongitude(), $this->eastNorth->getLongitude()),
-            $this->eastNorth->getLatitude() - $this->westSouth->getLatitude()
+        return new LatLng(
+            $this->northEast->getLatitude() - $this->southWest->getLatitude(),
+            $this->lngSpan($this->southWest->getLongitude(), $this->northEast->getLongitude())
         );
     }
 
     public function offsetExists($offset)
     {
-        return in_array($offset, self::$westSouthKeys) ||
-               in_array($offset, self::$eastNorthKeys) ||
+        return in_array($offset, self::$southWestKeys) ||
+               in_array($offset, self::$northEastKeys) ||
                in_array($offset, array('center', 'span'));
     }
 
     public function offsetGet($offset)
     {
-        if (in_array($offset, self::$westSouthKeys)) {
-            return $this->getWestSouth();
+        if (in_array($offset, self::$southWestKeys)) {
+            return $this->getSouthWest();
         }
 
-        if (in_array($offset, self::$eastNorthKeys)) {
-            return $this->getEastNorth();
+        if (in_array($offset, self::$northEastKeys)) {
+            return $this->getNorthEast();
         }
 
         if ('center' === $offset) {
@@ -131,18 +131,18 @@ class Bounds implements \ArrayAccess
      */
     public function crossesAntimeridian()
     {
-        return $this->westSouth->getLongitude() > $this->eastNorth->getLongitude();
+        return $this->southWest->getLongitude() > $this->northEast->getLongitude();
     }
 
     /**
-     * @param  \Geokit\LngLat $latLng
+     * @param  \Geokit\LatLng $latLng
      * @return boolean
      */
-    public function contains(LngLat $latLng)
+    public function contains(LatLng $latLng)
     {
       // check latitude
-      if ($this->westSouth->getLatitude() > $latLng->getLatitude() ||
-          $latLng->getLatitude() > $this->eastNorth->getLatitude()) {
+      if ($this->southWest->getLatitude() > $latLng->getLatitude() ||
+          $latLng->getLatitude() > $this->northEast->getLatitude()) {
           return false;
       }
 
@@ -151,16 +151,16 @@ class Bounds implements \ArrayAccess
     }
 
     /**
-     * @param  LngLat $latLng
+     * @param  LatLng $latLng
      * @return Bounds
      */
-    public function extend(LngLat $latLng)
+    public function extend(LatLng $latLng)
     {
-        $newSouth = min($this->westSouth->getLatitude(), $latLng->getLatitude());
-        $newNorth = max($this->eastNorth->getLatitude(), $latLng->getLatitude());
+        $newSouth = min($this->southWest->getLatitude(), $latLng->getLatitude());
+        $newNorth = max($this->northEast->getLatitude(), $latLng->getLatitude());
 
-        $newWest = $this->westSouth->getLongitude();
-        $newEast = $this->eastNorth->getLongitude();
+        $newWest = $this->southWest->getLongitude();
+        $newEast = $this->northEast->getLongitude();
 
         if (!$this->containsLng($latLng->getLongitude())) {
             // try extending east and try extending west, and use the one that
@@ -175,7 +175,7 @@ class Bounds implements \ArrayAccess
             }
         }
 
-        return new self(new LngLat($newWest, $newSouth), new LngLat($newEast, $newNorth));
+        return new self(new LatLng($newSouth, $newWest), new LatLng($newNorth, $newEast));
     }
 
     /**
@@ -184,9 +184,9 @@ class Bounds implements \ArrayAccess
      */
     public function union(Bounds $bounds)
     {
-        $newBounds = $this->extend($bounds->getWestSouth());
+        $newBounds = $this->extend($bounds->getSouthWest());
 
-        return $newBounds->extend($bounds->getEastNorth());
+        return $newBounds->extend($bounds->getNorthEast());
     }
 
     /**
@@ -198,11 +198,11 @@ class Bounds implements \ArrayAccess
     protected function containsLng($lng)
     {
         if ($this->crossesAntimeridian()) {
-            return $lng <= $this->eastNorth->getLongitude() ||
-                   $lng >= $this->westSouth->getLongitude();
+            return $lng <= $this->northEast->getLongitude() ||
+                   $lng >= $this->southWest->getLongitude();
         } else {
-            return $this->westSouth->getLongitude() <= $lng &&
-                   $lng <= $this->eastNorth->getLongitude();
+            return $this->southWest->getLongitude() <= $lng &&
+                   $lng <= $this->northEast->getLongitude();
         }
     }
 
@@ -228,22 +228,22 @@ class Bounds implements \ArrayAccess
      * If $input is a string, it can be in the format
      * "1.1234, 2.5678, 3.910, 4.1112" or "1.1234 2.5678 3.910 4.1112".
      *
-     * If $input is an array or \ArrayAccess object, it must have a west-south
+     * If $input is an array or \ArrayAccess object, it must have a south-west
      * and east-north entry.
      *
      * Recognized keys are:
      *
-     *  * West-south:
-     *    * westsouth
-     *    * west_south
-     *    * westSouth
+     *  * South-west:
+     *    * southwest
+     *    * south_west
+     *    * southWest
      *
-     *  * East-north:
-     *    * eastnorth
-     *    * east_north
-     *    * eastNorth
+     *  * North-east:
+     *    * northeast
+     *    * north_east
+     *    * northEast
      *
-     * If $input is an indexed array, it assumes west-south at index 0 and
+     * If $input is an indexed array, it assumes south-west at index 0 and
      * east-north at index 1, eg. [[180.0, -45.0], [-180.0, 45.0]].
      *
      * If $input is an Bounds object, it is just passed through.
@@ -258,29 +258,29 @@ class Bounds implements \ArrayAccess
             return $input;
         }
 
-        $westSouth = null;
-        $eastNorth = null;
+        $southWest = null;
+        $northEast = null;
 
         if (is_string($input) && preg_match('/(\-?\d+\.?\d*)[, ] ?(\-?\d+\.?\d*)[, ] ?(\-?\d+\.?\d*)[, ] ?(\-?\d+\.?\d*)$/', $input, $match)) {
-            $westSouth = array('lng' => $match[1], 'lat' => $match[2]);
-            $eastNorth = array('lng' => $match[3], 'lat' => $match[4]);
+            $southWest = array('lng' => $match[1], 'lat' => $match[2]);
+            $northEast = array('lng' => $match[3], 'lat' => $match[4]);
         } elseif (is_array($input) || $input instanceof \ArrayAccess) {
-            $westSouth = self::extract($input, self::$westSouthKeys);
+            $southWest = self::extract($input, self::$southWestKeys);
 
-            if (!$westSouth && isset($input[1])) {
-                $westSouth = $input[0];
+            if (!$southWest && isset($input[1])) {
+                $southWest = $input[0];
             }
 
-            $eastNorth = self::extract($input, self::$eastNorthKeys);
+            $northEast = self::extract($input, self::$northEastKeys);
 
-            if (!$eastNorth && isset($input[0])) {
-                $eastNorth = $input[1];
+            if (!$northEast && isset($input[0])) {
+                $northEast = $input[1];
             }
         }
 
-        if (null !== $westSouth && null !== $eastNorth) {
+        if (null !== $southWest && null !== $northEast) {
             try {
-                return new self(LngLat::normalize($westSouth), LngLat::normalize($eastNorth));
+                return new self(LatLng::normalize($southWest), LatLng::normalize($northEast));
             } catch (\InvalidArgumentException $e) {
                 throw new \InvalidArgumentException(sprintf('Cannot normalize Bounds from input %s.', json_encode($input)), 0, $e);
             }

--- a/src/LatLng.php
+++ b/src/LatLng.php
@@ -11,10 +11,10 @@
 
 namespace Geokit;
 
-class LngLat implements \ArrayAccess
+class LatLng implements \ArrayAccess
 {
-    private $longitude;
     private $latitude;
+    private $longitude;
 
     private static $longitudeKeys = array(
         'longitude',
@@ -33,10 +33,10 @@ class LngLat implements \ArrayAccess
      * @param float $longitude
      * @param float $latitude
      */
-    public function __construct($longitude, $latitude)
+    public function __construct($latitude, $longitude)
     {
-        $this->longitude = self::normalizeLng((float) $longitude);
         $this->latitude = self::normalizeLat((float) $latitude);
+        $this->longitude = self::normalizeLng((float) $longitude);
     }
 
     /**
@@ -76,12 +76,12 @@ class LngLat implements \ArrayAccess
 
     public function offsetUnset($offset)
     {
-        throw new \BadMethodCallException('LngLat is immutable.');
+        throw new \BadMethodCallException('LatLng is immutable.');
     }
 
     public function offsetSet($offset, $value)
     {
-        throw new \BadMethodCallException('LngLat is immutable.');
+        throw new \BadMethodCallException('LatLng is immutable.');
     }
 
     /**
@@ -89,15 +89,15 @@ class LngLat implements \ArrayAccess
      */
     public function __toString()
     {
-        return sprintf('%F,%F', $this->getLongitude(), $this->getLatitude());
+        return sprintf('%F,%F', $this->getLatitude(), $this->getLongitude());
     }
 
     /**
-     * Takes anything which looks like a coordinate and generates a LngLat
+     * Takes anything which looks like a coordinate and generates a LatLng
      * object from it.
      *
      * $input can be either a string, an array, an \ArrayAccess object or a
-     * LngLat object.
+     * LatLng object.
      *
      * If $input is a string, it can be in the format "1.1234, 2.5678" or
      * "1.1234 2.5678".
@@ -121,10 +121,10 @@ class LngLat implements \ArrayAccess
      * If $input is an indexed array, it assumes the longitude at index 0
      * and the latitude at index 1, eg. [180.0, 90.0].
      *
-     * If $input is an LngLat object, it is just passed through.
+     * If $input is an LatLng object, it is just passed through.
      *
-     * @param  string|array|\ArrayAccess|\Geokit\LngLat $input
-     * @return \Geokit\LngLat
+     * @param  string|array|\ArrayAccess|\Geokit\LatLng $input
+     * @return \Geokit\LatLng
      * @throws \InvalidArgumentException
      */
     public static function normalize($input)
@@ -137,27 +137,27 @@ class LngLat implements \ArrayAccess
         $lng = null;
 
         if (is_string($input) && preg_match('/(\-?\d+\.?\d*)[, ] ?(\-?\d+\.?\d*)$/', $input, $match)) {
-            $lng = $match[1];
-            $lat = $match[2];
+            $lat = $match[1];
+            $lng = $match[2];
         } elseif (is_array($input) || $input instanceof \ArrayAccess) {
             $lat = self::extract($input, self::$latitudeKeys);
 
-            if (!$lat && isset($input[1])) {
-                $lat = $input[1];
+            if (!$lat && isset($input[0])) {
+                $lat = $input[0];
             }
 
             $lng = self::extract($input, self::$longitudeKeys);
 
-            if (!$lng && isset($input[0])) {
-                $lng = $input[0];
+            if (!$lng && isset($input[1])) {
+                $lng = $input[1];
             }
         }
 
         if (is_numeric($lat) && is_numeric($lng)) {
-            return new self($lng, $lat);
+            return new self($lat, $lng);
         }
 
-        throw new \InvalidArgumentException(sprintf('Cannot normalize LngLat from input %s.', json_encode($input)));
+        throw new \InvalidArgumentException(sprintf('Cannot normalize LatLng from input %s.', json_encode($input)));
     }
 
     /**

--- a/src/Math.php
+++ b/src/Math.php
@@ -34,8 +34,8 @@ class Math
      */
     public function distanceHaversine($from, $to)
     {
-        $from = LngLat::normalize($from);
-        $to = LngLat::normalize($to);
+        $from = LatLng::normalize($from);
+        $to = LatLng::normalize($to);
 
         $lat1 = deg2rad($from->getLatitude());
         $lng1 = deg2rad($from->getLongitude());
@@ -66,8 +66,8 @@ class Math
      */
     public function distanceVincenty($from, $to)
     {
-        $from = LngLat::normalize($from);
-        $to = LngLat::normalize($to);
+        $from = LatLng::normalize($from);
+        $to = LatLng::normalize($to);
 
         $lat1 = $from->getLatitude();
         $lng1 = $from->getLongitude();
@@ -142,8 +142,8 @@ class Math
      */
     public function heading($from, $to)
     {
-        $from = LngLat::normalize($from);
-        $to = LngLat::normalize($to);
+        $from = LatLng::normalize($from);
+        $to = LatLng::normalize($to);
 
         $lat1 = $from->getLatitude();
         $lng1 = $from->getLongitude();
@@ -170,12 +170,12 @@ class Math
      * @see http://www.movable-type.co.uk/scripts/latlong.html
      * @param  mixed          $from
      * @param  mixed          $to
-     * @return \Geokit\LngLat
+     * @return \Geokit\LatLng
      */
     public function midpoint($from, $to)
     {
-        $from = LngLat::normalize($from);
-        $to = LngLat::normalize($to);
+        $from = LatLng::normalize($from);
+        $to = LatLng::normalize($to);
 
         $lat1 = $from->getLatitude();
         $lng1 = $from->getLongitude();
@@ -193,7 +193,7 @@ class Math
                 sqrt((cos($lat1) + $Bx) * (cos($lat1) + $Bx) + $By * $By));
         $lon3 = deg2rad($lng1) + atan2($By, cos($lat1) + $Bx);
 
-        return new LngLat(rad2deg($lon3), rad2deg($lat3));
+        return new LatLng(rad2deg($lat3), rad2deg($lon3));
     }
 
     /**
@@ -204,11 +204,11 @@ class Math
      * @param  mixed                                      $start
      * @param  float                                      $heading  (in degrees)
      * @param  string|array|\ArrayAccess|\Geokit\Distance $distance (in meters)
-     * @return \Geokit\LngLat
+     * @return \Geokit\LatLng
      */
     public function endpoint($start, $heading, $distance)
     {
-        $start = LngLat::normalize($start);
+        $start = LatLng::normalize($start);
         $distance = Distance::normalize($distance);
 
         $lat = deg2rad($start->getLatitude());
@@ -222,6 +222,6 @@ class Math
         $lon2 = $lng + atan2(sin($heading) * sin($angularDistance) * cos($lat),
                 cos($angularDistance) - sin($lat) * sin($lat2));
 
-        return new LngLat(rad2deg($lon2), rad2deg($lat2));
+        return new LatLng(rad2deg($lat2), rad2deg($lon2));
     }
 }

--- a/tests/BoundsTest.php
+++ b/tests/BoundsTest.php
@@ -25,49 +25,49 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
      */
     protected function assertBounds(Bounds $b, $w, $s, $e, $n)
     {
-        $this->assertEquals($w, $b->getWestSouth()->getLongitude());
-        $this->assertEquals($s, $b->getWestSouth()->getLatitude());
-        $this->assertEquals($e, $b->getEastNorth()->getLongitude());
-        $this->assertEquals($n, $b->getEastNorth()->getLatitude());
+        $this->assertEquals($w, $b->getSouthWest()->getLongitude());
+        $this->assertEquals($s, $b->getSouthWest()->getLatitude());
+        $this->assertEquals($e, $b->getNorthEast()->getLongitude());
+        $this->assertEquals($n, $b->getNorthEast()->getLatitude());
     }
 
-    public function testConstructorShouldAcceptLngLatsAsFirstAndSecondArgument()
+    public function testConstructorShouldAcceptLatLngsAsFirstAndSecondArgument()
     {
-        $bounds = new Bounds(new LngLat(1.1234, 2.5678), new LngLat(3.1234, 4.5678));
+        $bounds = new Bounds(new LatLng(2.5678, 1.1234), new LatLng(4.5678, 3.1234));
 
-        $this->assertTrue($bounds->getWestSouth() instanceof LngLat);
-        $this->assertEquals(1.1234, $bounds->getWestSouth()->getLongitude());
-        $this->assertEquals(2.5678, $bounds->getWestSouth()->getLatitude());
+        $this->assertTrue($bounds->getSouthWest() instanceof LatLng);
+        $this->assertEquals(1.1234, $bounds->getSouthWest()->getLongitude());
+        $this->assertEquals(2.5678, $bounds->getSouthWest()->getLatitude());
 
-        $this->assertTrue($bounds->getEastNorth() instanceof LngLat);
-        $this->assertEquals(3.1234, $bounds->getEastNorth()->getLongitude());
-        $this->assertEquals(4.5678, $bounds->getEastNorth()->getLatitude());
+        $this->assertTrue($bounds->getNorthEast() instanceof LatLng);
+        $this->assertEquals(3.1234, $bounds->getNorthEast()->getLongitude());
+        $this->assertEquals(4.5678, $bounds->getNorthEast()->getLatitude());
     }
 
     public function testConstructorShouldThrowExceptionForInvalidSouthCoordinate()
     {
         $this->setExpectedException('\LogicException');
-        new Bounds(new LngLat(90, 1), new LngLat(90, 0));
+        new Bounds(new LatLng(1, 90), new LatLng(0, 90));
     }
 
-    public function testGetCenterShouldReturnALngLatObject()
+    public function testGetCenterShouldReturnALatLngObject()
     {
-        $bounds = new Bounds(new LngLat(1.1234, 2.5678), new LngLat(3.1234, 4.5678));
-        $center = new LngLat(2.1234, 3.5678);
+        $bounds = new Bounds(new LatLng(2.5678, 1.1234), new LatLng(4.5678, 3.1234));
+        $center = new LatLng(3.5678, 2.1234);
 
         $this->assertEquals($center, $bounds->getCenter());
 
-        $bounds = new Bounds(new LngLat(179, -45), new LngLat(-179, 45));
-        $center = new LngLat(180, 0);
+        $bounds = new Bounds(new LatLng(-45, 179), new LatLng(45, -179));
+        $center = new LatLng(0, 180);
 
         $this->assertEquals($center, $bounds->getCenter());
     }
 
-    public function testGetSpanShouldReturnALngLatObject()
+    public function testGetSpanShouldReturnALatLngObject()
     {
-        $bounds = new Bounds(new LngLat(1.1234, 2.5678), new LngLat(3.1234, 4.5678));
+        $bounds = new Bounds(new LatLng(2.5678, 1.1234), new LatLng(4.5678, 3.1234));
 
-        $span = new LngLat(2, 2);
+        $span = new LatLng(2, 2);
 
         $this->assertEquals($span, $bounds->getSpan());
     }
@@ -75,18 +75,18 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
     public function testArrayAccess()
     {
         $keys = array(
-            'westsouth',
-            'west_south',
-            'westSouth',
-            'eastnorth',
-            'east_north',
-            'eastNorth',
+            'southwest',
+            'south_west',
+            'southWest',
+            'northeast',
+            'north_east',
+            'northEast',
 
             'center',
             'span'
         );
 
-        $bounds = new Bounds(new LngLat(1.1234, 2.5678), new LngLat(3.1234, 4.5678));
+        $bounds = new Bounds(new LatLng(2.5678, 1.1234), new LatLng(4.5678, 3.1234));
 
         foreach ($keys as $key) {
             $this->assertTrue(isset($bounds[$key]));
@@ -98,7 +98,7 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\InvalidArgumentException', 'Invalid offset "foo".');
 
-        $bounds = new Bounds(new LngLat(1.1234, 2.5678), new LngLat(3.1234, 4.5678));
+        $bounds = new Bounds(new LatLng(2.5678, 1.1234), new LatLng(4.5678, 3.1234));
 
         $bounds['foo'];
     }
@@ -107,7 +107,7 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\BadMethodCallException');
 
-        $bounds = new Bounds(new LngLat(1.1234, 2.5678), new LngLat(3.1234, 4.5678));
+        $bounds = new Bounds(new LatLng(2.5678, 1.1234), new LatLng(4.5678, 3.1234));
 
         $bounds['southwest'] = 5;
     }
@@ -116,42 +116,42 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\BadMethodCallException');
 
-        $bounds = new Bounds(new LngLat(1.1234, 2.5678), new LngLat(3.1234, 4.5678));
+        $bounds = new Bounds(new LatLng(2.5678, 1.1234), new LatLng(4.5678, 3.1234));
 
         unset($bounds['southwest']);
     }
 
     public function testContains()
     {
-        $bounds = new Bounds(new LngLat(37, -122), new LngLat(38, -123));
+        $bounds = new Bounds(new LatLng(-122, 37), new LatLng(-123, 38));
 
-        $this->assertTrue($bounds->contains(new LngLat(37, -122)));
-        $this->assertTrue($bounds->contains(new LngLat(38, -123)));
+        $this->assertTrue($bounds->contains(new LatLng(-122, 37)));
+        $this->assertTrue($bounds->contains(new LatLng(-123, 38)));
 
-        $this->assertFalse($bounds->contains(new LngLat(-12, -70)));
+        $this->assertFalse($bounds->contains(new LatLng(-70, -12)));
     }
 
     public function testExtendInACircle()
     {
-        $bounds = new Bounds(new LngLat(0, 0), new LngLat(0, 0));
-        $bounds = $bounds->extend(new LngLat(1, 0));
-        $bounds = $bounds->extend(new LngLat(0, 1));
-        $bounds = $bounds->extend(new LngLat(-1, 0));
-        $bounds = $bounds->extend(new LngLat(0, -1));
+        $bounds = new Bounds(new LatLng(0, 0), new LatLng(0, 0));
+        $bounds = $bounds->extend(new LatLng(0, 1));
+        $bounds = $bounds->extend(new LatLng(1, 0));
+        $bounds = $bounds->extend(new LatLng(0, -1));
+        $bounds = $bounds->extend(new LatLng(-1, 0));
         $this->assertBounds($bounds, -1, -1, 1, 1);
     }
 
     public function testUnion()
     {
-        $bounds = new Bounds(new LngLat(-122, 37), new LngLat(-122, 37));
+        $bounds = new Bounds(new LatLng(37, -122), new LatLng(37, -122));
 
-        $bounds = $bounds->union(new Bounds(new LngLat(123, -38), new LngLat(-123, 38)));
+        $bounds = $bounds->union(new Bounds(new LatLng(-38, 123), new LatLng(38, -123)));
         $this->assertBounds($bounds, 123, -38, -122, 38);
     }
 
     public function testCrossesAntimeridian()
     {
-        $bounds = new Bounds(new LngLat(179, -45), new LngLat(-179, 45));
+        $bounds = new Bounds(new LatLng(-45, 179), new LatLng(45, -179));
 
         $this->assertTrue($bounds->crossesAntimeridian());
         $this->assertEquals(90, $bounds->getSpan()->getLatitude());
@@ -160,9 +160,9 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
 
     public function testCrossesAntimeridianViaExtend()
     {
-        $bounds = new Bounds(new LngLat(179, -45), new LngLat(-179, 45));
+        $bounds = new Bounds(new LatLng(-45, 179), new LatLng(45, -179));
 
-        $bounds = $bounds->extend(new LngLat(-180, 90));
+        $bounds = $bounds->extend(new LatLng(90, -180));
 
         $this->assertTrue($bounds->crossesAntimeridian());
         $this->assertEquals(90, $bounds->getSpan()->getLatitude());
@@ -171,7 +171,7 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizeShouldAcceptBoundsArgument()
     {
-        $bounds1 = new Bounds(new LngLat(179, -45), new LngLat(-179, 45));
+        $bounds1 = new Bounds(new LatLng(-45, 179), new LatLng(45, -179));
         $bounds2 = Bounds::normalize($bounds1);
 
         $this->assertEquals($bounds1, $bounds2);
@@ -197,26 +197,26 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizeShouldAcceptArrayArgumentDataProvider()
     {
-        $westSouthKeys = array(
-            'westsouth',
-            'west_south',
-            'westSouth'
+        $southWestKeys = array(
+            'southwest',
+            'south_west',
+            'southWest',
         );
 
-        $eastNorthKeys = array(
-            'eastnorth',
-            'east_north',
-            'eastNorth'
+        $northEastKeys = array(
+            'northeast',
+            'north_east',
+            'northEast',
         );
 
         $data = array();
 
-        foreach ($westSouthKeys as $westSouthKey) {
-            foreach ($eastNorthKeys as $eastNorthKey) {
+        foreach ($southWestKeys as $southWestKey) {
+            foreach ($northEastKeys as $northEastKey) {
                 $data[] = array(
                     array(
-                        $westSouthKey => array(179, -45),
-                        $eastNorthKey => array(-179, 45)
+                        $southWestKey => array(-45, 179),
+                        $northEastKey => array(45, -179)
                     )
                 );
             }
@@ -224,8 +224,8 @@ class BoundsTest extends \PHPUnit_Framework_TestCase
 
         $data[] = array(
             array(
-                array(179, -45),
-                array(-179, 45)
+                array(-45, 179),
+                array(45, -179)
             )
         );
 

--- a/tests/LngLatTest.php
+++ b/tests/LngLatTest.php
@@ -12,32 +12,32 @@
 namespace Geokit;
 
 /**
- * @covers Geokit\LngLat
+ * @covers Geokit\LatLng
  */
-class LngLatTest extends \PHPUnit_Framework_TestCase
+class LatLngTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorShouldAcceptStringsAsArguments()
     {
-        $LngLat = new LngLat('1.1234', '2.5678');
+        $LatLng = new LatLng('2.5678', '1.1234');
 
-        $this->assertSame(1.1234, $LngLat->getLongitude());
-        $this->assertSame(2.5678, $LngLat->getLatitude());
+        $this->assertSame(1.1234, $LatLng->getLongitude());
+        $this->assertSame(2.5678, $LatLng->getLatitude());
     }
 
     public function testConstructorShouldAcceptFloatsAsArguments()
     {
-        $LngLat = new LngLat(1.1234, 2.5678);
+        $LatLng = new LatLng(2.5678, 1.1234);
 
-        $this->assertSame(1.1234, $LngLat->getLongitude());
-        $this->assertSame(2.5678, $LngLat->getLatitude());
+        $this->assertSame(1.1234, $LatLng->getLongitude());
+        $this->assertSame(2.5678, $LatLng->getLatitude());
     }
 
-    public function testConstructorShouldNormalizeLngLat()
+    public function testConstructorShouldNormalizeLatLng()
     {
-        $LngLat = new LngLat(181, 91);
+        $LatLng = new LatLng(91, 181);
 
-        $this->assertEquals(-179, $LngLat->getLongitude());
-        $this->assertEquals(90, $LngLat->getLatitude());
+        $this->assertEquals(-179, $LatLng->getLongitude());
+        $this->assertEquals(90, $LatLng->getLatitude());
     }
 
     public function testConstructorShouldAcceptLocalizedFloatsAsArguments()
@@ -48,10 +48,10 @@ class LngLatTest extends \PHPUnit_Framework_TestCase
         $latitude  = floatval('1.1234');
         $longitude = floatval('2.5678');
 
-        $LngLat = new LngLat($longitude, $latitude);
+        $LatLng = new LatLng($latitude, $longitude);
 
-        $this->assertSame(1.1234, $LngLat->getLatitude());
-        $this->assertSame(2.5678, $LngLat->getLongitude());
+        $this->assertSame(1.1234, $LatLng->getLatitude());
+        $this->assertSame(2.5678, $LatLng->getLongitude());
 
         setlocale(LC_NUMERIC, $currentLocale);
     }
@@ -68,11 +68,11 @@ class LngLatTest extends \PHPUnit_Framework_TestCase
             'x'
         );
 
-        $LngLat = new LngLat(1, 2);
+        $LatLng = new LatLng(2, 1);
 
         foreach ($keys as $key) {
-            $this->assertTrue(isset($LngLat[$key]));
-            $this->assertNotNull($LngLat[$key]);
+            $this->assertTrue(isset($LatLng[$key]));
+            $this->assertNotNull($LatLng[$key]);
         }
     }
 
@@ -80,34 +80,34 @@ class LngLatTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\InvalidArgumentException', 'Invalid offset "foo".');
 
-        $LngLat = new LngLat(1, 2);
+        $LatLng = new LatLng(2, 1);
 
-        $LngLat['foo'];
+        $LatLng['foo'];
     }
 
     public function testOffsetSetThrowsException()
     {
         $this->setExpectedException('\BadMethodCallException');
 
-        $LngLat = new LngLat(1, 2);
+        $LatLng = new LatLng(2, 1);
 
-        $LngLat['lat'] = 5;
+        $LatLng['lat'] = 5;
     }
 
     public function testOffsetUnsetThrowsException()
     {
         $this->setExpectedException('\BadMethodCallException');
 
-        $LngLat = new LngLat(1, 2);
+        $LatLng = new LatLng(2, 1);
 
-        unset($LngLat['lat']);
+        unset($LatLng['lat']);
     }
 
     public function testToStringShouldReturnLatitudeAndLongitudeAsCommaSeparatedString()
     {
-        $LngLat = new LngLat(1.1234, 2.5678);
+        $LatLng = new LatLng(2.5678, 1.1234);
 
-        $this->assertSame(sprintf('%F,%F', 1.1234, 2.5678), (string) $LngLat);
+        $this->assertSame(sprintf('%F,%F', 2.5678, 1.1234), (string) $LatLng);
     }
 
     public function testToStringShouldReturnLatitudeAndLongitudeAsCommaSeparatedStringWithLocalizedFloats()
@@ -118,77 +118,77 @@ class LngLatTest extends \PHPUnit_Framework_TestCase
         $latitude  = floatval('1.1234');
         $longitude = floatval('2.5678');
 
-        $LngLat = new LngLat($latitude, $longitude);
+        $LatLng = new LatLng($latitude, $longitude);
 
-        $this->assertSame(sprintf('%F,%F', 1.1234, 2.5678), (string) $LngLat);
+        $this->assertSame(sprintf('%F,%F', 1.1234, 2.5678), (string) $LatLng);
         setlocale(LC_NUMERIC, $currentLocale);
     }
 
     public function testNormalizeShouldThrowExceptionIfInvalidDataSupplied()
     {
-        $this->setExpectedException('\InvalidArgumentException', 'Cannot normalize LngLat from input null.');
-        LngLat::normalize(null);
+        $this->setExpectedException('\InvalidArgumentException', 'Cannot normalize LatLng from input null.');
+        LatLng::normalize(null);
     }
 
-    public function testNormalizeShouldAcceptLngLatArgument()
+    public function testNormalizeShouldAcceptLatLngArgument()
     {
-        $LngLat1 = new LngLat(1.1234, 2.5678);
-        $LngLat2 = LngLat::normalize($LngLat1);
+        $LatLng1 = new LatLng(2.5678, 1.1234);
+        $LatLng2 = LatLng::normalize($LatLng1);
 
-        $this->assertEquals($LngLat1, $LngLat2);
+        $this->assertEquals($LatLng1, $LatLng2);
     }
 
     public function testNormalizeShouldAcceptStringArgument()
     {
-        $LngLat = LngLat::normalize('1.1234,2.5678');
+        $LatLng = LatLng::normalize('1.1234,2.5678');
 
-        $this->assertSame(1.1234, $LngLat->getLongitude());
-        $this->assertSame(2.5678, $LngLat->getLatitude());
+        $this->assertSame(1.1234, $LatLng->getLatitude());
+        $this->assertSame(2.5678, $LatLng->getLongitude());
     }
 
     public function testNormalizeShouldAcceptArrayArgument()
     {
-        $LngLat = LngLat::normalize(array('latitude' => 1.1234, 'longitude' => 2.5678));
+        $LatLng = LatLng::normalize(array('latitude' => 1.1234, 'longitude' => 2.5678));
 
-        $this->assertSame(1.1234, $LngLat->getLatitude());
-        $this->assertSame(2.5678, $LngLat->getLongitude());
+        $this->assertSame(1.1234, $LatLng->getLatitude());
+        $this->assertSame(2.5678, $LatLng->getLongitude());
     }
 
     public function testNormalizeShouldAcceptArrayArgumentWithShortKeys()
     {
-        $LngLat = LngLat::normalize(array('lat' => 1.1234, 'lon' => 2.5678));
+        $LatLng = LatLng::normalize(array('lat' => 1.1234, 'lon' => 2.5678));
 
-        $this->assertSame(1.1234, $LngLat->getLatitude());
-        $this->assertSame(2.5678, $LngLat->getLongitude());
+        $this->assertSame(1.1234, $LatLng->getLatitude());
+        $this->assertSame(2.5678, $LatLng->getLongitude());
 
-        $LngLat = LngLat::normalize(array('lat' => 1.1234, 'lng' => 2.5678));
+        $LatLng = LatLng::normalize(array('lat' => 1.1234, 'lng' => 2.5678));
 
-        $this->assertSame(1.1234, $LngLat->getLatitude());
-        $this->assertSame(2.5678, $LngLat->getLongitude());
+        $this->assertSame(1.1234, $LatLng->getLatitude());
+        $this->assertSame(2.5678, $LatLng->getLongitude());
     }
 
     public function testNormalizeShouldAcceptArrayArgumentWithXYKeys()
     {
-        $LngLat = LngLat::normalize(array('y' => 1.1234, 'x' => 2.5678));
+        $LatLng = LatLng::normalize(array('y' => 1.1234, 'x' => 2.5678));
 
-        $this->assertSame(1.1234, $LngLat->getLatitude());
-        $this->assertSame(2.5678, $LngLat->getLongitude());
+        $this->assertSame(1.1234, $LatLng->getLatitude());
+        $this->assertSame(2.5678, $LatLng->getLongitude());
     }
 
     public function testNormalizeShouldAcceptArrayAccessArgument()
     {
-        $LngLat = LngLat::normalize(new \ArrayObject(array('latitude' => 1.1234, 'longitude' => 2.5678)));
+        $LatLng = LatLng::normalize(new \ArrayObject(array('latitude' => 1.1234, 'longitude' => 2.5678)));
 
-        $this->assertSame(1.1234, $LngLat->getLatitude());
-        $this->assertSame(2.5678, $LngLat->getLongitude());
+        $this->assertSame(1.1234, $LatLng->getLatitude());
+        $this->assertSame(2.5678, $LatLng->getLongitude());
     }
 
     public function testNormalizeShouldAcceptIndexedArrayArgument()
     {
-        $LngLat = LngLat::normalize(array(2.5678, 1.1234));
+        $LatLng = LatLng::normalize(array(2.5678, 1.1234));
 
-        $this->assertSame(1.1234, $LngLat->getLatitude());
-        $this->assertSame(2.5678, $LngLat->getLongitude());
+        $this->assertSame(2.5678, $LatLng->getLatitude());
+        $this->assertSame(1.1234, $LatLng->getLongitude());
     }
 
     /**
@@ -196,7 +196,7 @@ class LngLatTest extends \PHPUnit_Framework_TestCase
      */
     public function testNormalizeLat($a, $b)
     {
-        $this->assertEquals(LngLat::normalizeLat($a), $b);
+        $this->assertEquals(LatLng::normalizeLat($a), $b);
     }
 
     public function testNormalizeLatDataProvider()
@@ -215,7 +215,7 @@ class LngLatTest extends \PHPUnit_Framework_TestCase
      */
     public function testNormalizeLng($a, $b)
     {
-        $this->assertEquals(LngLat::normalizeLng($a), $b);
+        $this->assertEquals(LatLng::normalizeLng($a), $b);
     }
 
     public function testNormalizeLngDataProvider()

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -19,13 +19,13 @@ class MathTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testDistanceHaversineDataProvider
      */
-    public function testDistanceHaversine($LngLat1, $LngLat2, $distance)
+    public function testDistanceHaversine($LatLng1, $LatLng2, $distance)
     {
         $math = new Math();
 
         $this->assertEquals(
             sprintf('%F', $distance),
-            sprintf('%F', $math->distanceHaversine($LngLat1, $LngLat2)->meters())
+            sprintf('%F', $math->distanceHaversine($LatLng1, $LatLng2)->meters())
         );
     }
 
@@ -138,13 +138,13 @@ class MathTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testDistanceVincentyDataProvider
      */
-    public function testDistanceVincenty($LngLat1, $LngLat2, $distance)
+    public function testDistanceVincenty($LatLng1, $LatLng2, $distance)
     {
         $math = new Math();
 
         $this->assertEquals(
             sprintf('%F', $distance),
-            sprintf('%F', $math->distanceVincenty($LngLat1, $LngLat2)->meters())
+            sprintf('%F', $math->distanceVincenty($LatLng1, $LatLng2)->meters())
         );
     }
 
@@ -260,7 +260,7 @@ class MathTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             sprintf('%F', 0),
-            sprintf('%F', $math->distanceVincenty(new LngLat(90, 90), new LngLat(90, 90))->meters())
+            sprintf('%F', $math->distanceVincenty(new LatLng(90, 90), new LatLng(90, 90))->meters())
         );
     }
 
@@ -269,7 +269,7 @@ class MathTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\RuntimeException', 'Vincenty formula failed to converge.');
 
         $math = new Math();
-        $math->distanceVincenty(new LngLat(0, 0), new LngLat(180, 0));
+        $math->distanceVincenty(new LatLng(0, 0), new LatLng(0, 180));
     }
 
     public function testHeading()


### PR DESCRIPTION
To match with services like [Google Maps](https://developers.google.com/maps/documentation/javascript/reference#LatLng) and [Mapbox](https://www.mapbox.com/mapbox-gl-js/api/#new-mapboxgl-latlng-latitude-longitude-), I've flipped latitude and longitude.
- westsouth => southwest, eastnorth => northeast
- LngLat => LatLng
