### PR TITLE
allow normalization of geo objects with getters

### DIFF
--- a/src/LatLng.php
+++ b/src/LatLng.php
@@ -135,6 +135,9 @@ class LatLng implements \ArrayAccess
         if (is_string($input) && preg_match('/(\-?\d+\.?\d*)[, ] ?(\-?\d+\.?\d*)$/', $input, $match)) {
             $lat = $match[1];
             $lng = $match[2];
+        } elseif (is_object($input) && method_exists($input, 'getLatitude') && method_exists($input, 'getLongitude')) {
+            $lat = $input->getLatitude();
+            $lng = $input->getLongitude();
         } elseif (is_array($input) || $input instanceof \ArrayAccess) {
             if (Utils::isNumericInputArray($input)) {
                 $lat = $input[0];

--- a/tests/Fixtures/ThirdPartyLatLng.php
+++ b/tests/Fixtures/ThirdPartyLatLng.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Geokit\Fixtures;
+
+class ThirdPartyLatLng
+{
+    private $lat;
+    private $lng;
+
+    public function __construct($lat, $lng)
+    {
+        $this->lat = $lat;
+        $this->lng = $lng;
+    }
+
+    public function getLatitude()
+    {
+        return $this->lat;
+    }
+
+    public function getLongitude()
+    {
+        return $this->lng;
+    }
+}

--- a/tests/LngLatTest.php
+++ b/tests/LngLatTest.php
@@ -2,6 +2,8 @@
 
 namespace Geokit;
 
+use Geokit\Fixtures\ThirdPartyLatLng;
+
 class LngLatTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorShouldAcceptStringsAsArguments()
@@ -174,6 +176,16 @@ class LngLatTest extends \PHPUnit_Framework_TestCase
     public function testNormalizeShouldAcceptIndexedArrayArgument()
     {
         $LatLng = LatLng::normalize(array(2.5678, 1.1234));
+
+        $this->assertSame(2.5678, $LatLng->getLatitude());
+        $this->assertSame(1.1234, $LatLng->getLongitude());
+    }
+
+    public function testNormalizeShouldAcceptObjectWithLatLngGetters()
+    {
+        $thirdPartyLatLng = new ThirdPartyLatLng(2.5678, 1.1234);
+
+        $LatLng = LatLng::normalize($thirdPartyLatLng);
 
         $this->assertSame(2.5678, $LatLng->getLatitude());
         $this->assertSame(1.1234, $LatLng->getLongitude());


### PR DESCRIPTION
As there is already normalization for different array structures, what about allowing objects with getters too? It should be a pretty common case.